### PR TITLE
make all reservoir-problem tests compile again

### DIFF
--- a/ewoms/io/vtkblackoilpolymermodule.hh
+++ b/ewoms/io/vtkblackoilpolymermodule.hh
@@ -1,0 +1,253 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Ewoms::VtkBlackOilPolymerModule
+ */
+#ifndef EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
+#define EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
+
+#include <opm/material/densead/Math.hpp>
+
+#include "vtkmultiwriter.hh"
+#include "baseoutputmodule.hh"
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+#include <ewoms/models/blackoil/blackoilproperties.hh>
+
+#include <dune/common/fvector.hh>
+
+#include <cstdio>
+
+namespace Ewoms {
+namespace Properties {
+// create new type tag for the VTK multi-phase output
+NEW_TYPE_TAG(VtkBlackOilPolymer);
+
+// create the property tags needed for the polymer output module
+NEW_PROP_TAG(EnablePolymer);
+NEW_PROP_TAG(EnableVtkOutput);
+NEW_PROP_TAG(VtkWritePolymerConcentration);
+NEW_PROP_TAG(VtkWritePolymerAlivePoreSpace);
+NEW_PROP_TAG(VtkWritePolymerAdsorption);
+NEW_PROP_TAG(VtkWritePolymerRockDensity);
+NEW_PROP_TAG(VtkWritePolymerViscosityCorrection);
+NEW_PROP_TAG(VtkWriteWaterViscosityCorrection);
+
+// set default values for what quantities to output
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerConcentration, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAlivePoreSpace, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerViscosityCorrection, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWriteWaterViscosityCorrection, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerRockDensity, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAdsorption, true);
+} // namespace Properties
+} // namespace Ewoms
+
+namespace Ewoms {
+/*!
+ * \ingroup Vtk
+ *
+ * \brief VTK output module for the black oil model's polymer related quantities.
+ */
+template <class TypeTag>
+class VtkBlackOilPolymerModule : public BaseOutputModule<TypeTag>
+{
+    typedef BaseOutputModule<TypeTag> ParentType;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    static const int vtkFormat = GET_PROP_VALUE(TypeTag, VtkOutputFormat);
+    typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
+
+    enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+
+    typedef typename ParentType::ScalarBuffer ScalarBuffer;
+
+public:
+    VtkBlackOilPolymerModule(const Simulator& simulator)
+        : ParentType(simulator)
+    { }
+
+    /*!
+     * \brief Register all run-time parameters for the multi-phase VTK output
+     * module.
+     */
+    static void registerParameters()
+    {
+        if (!enablePolymer)
+            return;
+
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerConcentration,
+                             "Include the concentration of the polymer component in the water phase "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace,
+                             "Include the fraction of the \"alive\" pore space "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerRockDensity,
+                             "Include the amount of already adsorbed polymer component"
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAdsorption,
+                             "Include the adsorption rate of the polymer component"
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection,
+                             "Include the viscosity correction of the polymer component "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteWaterViscosityCorrection,
+                             "Include the viscosity correction of the water component "
+                             "due to polymers in the VTK output files");
+    }
+
+    /*!
+     * \brief Allocate memory for the scalar fields we would like to
+     *        write to the VTK file.
+     */
+    void allocBuffers()
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        if (polymerConcentrationOutput_())
+            this->resizeScalarBuffer_(polymerConcentration_);
+        if (polymerAlivePoreSpaceOutput_())
+            this->resizeScalarBuffer_(polymerAlivePoreSpace_);
+        if (polymerRockDensityOutput_())
+            this->resizeScalarBuffer_(polymerRockDensity_);
+        if (polymerAdsorptionOutput_())
+            this->resizeScalarBuffer_(polymerAdsorption_);
+        if (polymerViscosityCorrectionOutput_())
+            this->resizeScalarBuffer_(polymerViscosityCorrection_);
+        if (waterViscosityCorrectionOutput_())
+            this->resizeScalarBuffer_(waterViscosityCorrection_);
+    }
+
+    /*!
+     * \brief Modify the internal buffers according to the intensive quantities relevant for
+     *        an element
+     */
+    void processElement(const ElementContext& elemCtx)
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
+            const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
+            unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+
+            if (polymerConcentrationOutput_())
+                polymerConcentration_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerConcentration());
+
+            if (polymerAlivePoreSpaceOutput_())
+                polymerAlivePoreSpace_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerAlivePoreSpace());
+
+            if (polymerRockDensityOutput_())
+                polymerRockDensity_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerRockDensity());
+
+            if (polymerAdsorptionOutput_())
+                polymerAdsorption_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerAdsorption());
+
+            if (polymerViscosityCorrectionOutput_())
+                polymerViscosityCorrection_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerViscosityCorrection());
+
+            if (waterViscosityCorrectionOutput_())
+                waterViscosityCorrection_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.waterViscosityCorrection());
+        }
+    }
+
+    /*!
+     * \brief Add all buffers to the VTK output writer.
+     */
+    void commitBuffers(BaseOutputWriter& baseWriter)
+    {
+        VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
+        if (!vtkWriter)
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        if (polymerConcentrationOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer concentration", polymerConcentration_);
+
+        if (polymerAlivePoreSpaceOutput_())
+            this->commitScalarBuffer_(baseWriter, "alive pore volume fraction", polymerAlivePoreSpace_);
+
+        if (polymerRockDensityOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer rock density", polymerRockDensity_);
+
+        if (polymerAdsorptionOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer adsorption", polymerAdsorption_);
+
+        if (polymerViscosityCorrectionOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer viscosity correction", polymerViscosityCorrection_);
+
+        if (waterViscosityCorrectionOutput_())
+            this->commitScalarBuffer_(baseWriter, "water viscosity correction", waterViscosityCorrection_);
+    }
+
+private:
+    static bool polymerConcentrationOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerConcentration); }
+
+    static bool polymerAlivePoreSpaceOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace); }
+
+    static bool polymerRockDensityOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerRockDensity); }
+
+    static bool polymerAdsorptionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerAdsorption); }
+
+    static bool polymerViscosityCorrectionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection); }
+
+    static bool waterViscosityCorrectionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection); }
+
+    ScalarBuffer polymerConcentration_;
+    ScalarBuffer polymerAlivePoreSpace_;
+    ScalarBuffer polymerRockDensity_;
+    ScalarBuffer polymerAdsorption_;
+    ScalarBuffer polymerViscosityCorrection_;
+    ScalarBuffer waterViscosityCorrection_;
+};
+} // namespace Ewoms
+
+#endif

--- a/ewoms/models/blackoil/blackoildarcyfluxmodule.hh
+++ b/ewoms/models/blackoil/blackoildarcyfluxmodule.hh
@@ -87,6 +87,9 @@ public:
 
     }
 
+    void updatePolymer(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
+    { asImp_().updateShearMultipliersPerm(elemCtx, scvfIdx, timeIdx); }
+
 protected:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -70,6 +70,7 @@ namespace Properties {
 NEW_TYPE_TAG(BlackOilModel, INHERITS_FROM(MultiPhaseBaseModel,
                                           VtkBlackOil,
                                           VtkBlackOilSolvent,
+                                          VtkBlackOilPolymer,
                                           VtkComposition));
 
 //! Set the local residual function

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -29,7 +29,7 @@
 #define EWOMS_BLACK_OIL_POLYMER_MODULE_HH
 
 #include "blackoilproperties.hh"
- // #include <ewoms/io/vtkblackoilpolymermodule.hh>
+#include <ewoms/io/vtkblackoilpolymermodule.hh>
 #include <ewoms/models/common/quantitycallbacks.hh>
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
@@ -365,10 +365,10 @@ public:
     static void registerParameters()
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return;
 
-        //Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
+        Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
     }
 
     /*!
@@ -378,16 +378,16 @@ public:
                                       Simulator& simulator)
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return;
 
-        //model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
+        model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
     }
 
     static bool primaryVarApplies(unsigned pvIdx)
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return false;
 
         return pvIdx == polymerConcentrationIdx;

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -1048,9 +1048,28 @@ class BlackOilPolymerExtensiveQuantities
     typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
 
 public:
+    /*!
+     * \brief Method which calculates the shear factor based on flow velocity
+     *
+     * This is the variant of the method which assumes that the problem is specified
+     * using permeabilities, i.e., *not* via transmissibilities.
+     */
+    template <class Dummy = bool> // we need to make this method a template to avoid
+                                  // compiler errors if it is not instantiated!
+    void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+                                    unsigned scvfIdx OPM_UNUSED,
+                                    unsigned timeIdx OPM_UNUSED)
+    {
+        OPM_THROW(std::runtime_error,
+                  "The extension of the blackoil model for polymers is not yet "
+                  "implemented for problems specified using permeabilities.");
+    }
 
     /*!
      * \brief Method which calculates the shear factor based on flow velocity
+     *
+     * This is the variant of the method which assumes that the problem is specified
+     * using transmissibilities, i.e., *not* via permeabilities.
      */
     template <class Dummy = bool> // we need to make this method a template to avoid
                                   // compiler errors if it is not instantiated!
@@ -1133,6 +1152,11 @@ public:
     void updateShearMultipliers(const ElementContext& elemCtx OPM_UNUSED,
                               unsigned scvfIdx OPM_UNUSED,
                               unsigned timeIdx OPM_UNUSED)
+    { }
+
+    void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+                                    unsigned scvfIdx OPM_UNUSED,
+                                    unsigned timeIdx OPM_UNUSED)
     { }
 
     const Evaluation& polymerShearFactor() const


### PR DESCRIPTION
basically, this means to add variants of the polymer shear factor computation methods which assume permeabilities as inputs. Note that although these methods are added by this PR, they are just dummies
which only throw an exception if the polymer extension is enabled for such problems.