### PR TITLE
add serialization templates to BlackOilBrineModule

### DIFF
--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -318,6 +318,29 @@ public:
         return !bdensityTable_.empty();
     }
 
+    template<class Serializer>
+    static std::size_t packSize(Serializer& serializer)
+    {
+        return serializer.packSize(bdensityTable_) +
+               serializer.packSize(referencePressure_);
+    }
+
+    template<class Serializer>
+    static void pack(std::vector<char>& buffer, int& position,
+                     Serializer& serializer)
+    {
+        serializer.pack(bdensityTable_, buffer, position);
+        serializer.pack(referencePressure_, buffer, position);
+    }
+
+    template<class Serializer>
+    static void unpack(std::vector<char>& buffer, int& position,
+                       Serializer& serializer)
+    {
+        serializer.unpack(bdensityTable_, buffer, position);
+        serializer.unpack(referencePressure_, buffer, position);
+    }
+
 private:
     static std::vector<TabulatedFunction> bdensityTable_;
     static std::vector<Scalar> referencePressure_;


### PR DESCRIPTION
This should be necessary, however there is no call to initFromDeck in the opm-simulators branch. Likely you want to monkey what is there for the other modules in eclproblem.hh.